### PR TITLE
Add Croatian translation

### DIFF
--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+    <string name="app_name">BookList</string>
+    <string name="pages">%1$d stranice</string>
+    <string name="bottom_line">Objavio %1$s in %2$s</string>
+    <string name="authors_pages_dot_separator">.</string>
+
+    <string name="loading">Učitavanje…</string>
+    <string name="no_further_description">Nema daljnjeg opisa</string>
+    <string name="book_cover">Naslovnica knjige</string>
+    <string name="search">Traži</string>
+    <string name="search_here">Traži ovdje</string>
+    <string name="get_it">Kupi</string>
+    <string name="preview">Pregled</string>
+    <string name="search_about">Pretraži o nečemu</string>
+</resources>


### PR DESCRIPTION
line 4: <string name="bottom_line">Objavio %1$s in %2$s</string> If you would like to include masculine and feminine you should white "Objavio/la" this contains both version which helps if the author is man an if it is a woman. "Objavio" would be only for man

Line 14: <string name="search_about">Pretraži o nečemu</string> "Pretraži o nečemu" literally  means Search about something, in Croatian "pretraži o" which means "Search about" is pretty confusing.