### PR TITLE
Add Indonesian translation

### DIFF
--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+    <string name="app_name">BookList</string>
+    <string name="pages">%1$d hlm.</string>
+    <string name="bottom_line">Diterbitkan oleh %1$s pada %2$s</string>
+    <string name="authors_pages_dot_separator">.</string>
+
+    <string name="loading">Memuat …</string>
+    <string name="no_further_description">Tidak ada deskripsi lebih lanjut</string>
+    <string name="book_cover">Sampul buku</string>
+    <string name="search">Cari</string>
+    <string name="search_here">Cari di sini</string>
+    <string name="get_it">Beli</string>
+    <string name="preview">Pratinjau</string>
+    <string name="search_about">Cari tentang</string>
+</resources>


### PR DESCRIPTION
I have added an Indonesian translation. I noticed that other translations used terms like "google it" for the "search about" string, but here I translated the term exactly as it is so you can verify the translation easily with Google Translate.
This is my first pull request, I hope I'm doing this right.